### PR TITLE
feat(`frontend`): query report submissions

### DIFF
--- a/src/lib/model/src/event.ts
+++ b/src/lib/model/src/event.ts
@@ -28,7 +28,7 @@ export const EarthquakeFilteringSchema = z.object({
 	orderTime: z.boolean().optional(),
 	geographicBound: BoundingBoxSchema.optional(),
 	coordinateCenter: CoordinatesSchema.optional(),
-    radius: z.number().optional(),
+	radius: z.number().optional(),
 	limit: z.number().optional()
 });
 

--- a/src/lib/model/src/event.ts
+++ b/src/lib/model/src/event.ts
@@ -27,6 +27,8 @@ export const EarthquakeFilteringSchema = z.object({
 	maxTime: z.string().datetime().optional(),
 	orderTime: z.boolean().optional(),
 	geographicBound: BoundingBoxSchema.optional(),
+	coordinateCenter: CoordinatesSchema.optional(),
+    radius: z.number().optional(),
 	limit: z.number().optional()
 });
 

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -87,8 +87,10 @@ export async function getAllEarthquakeData(
 		if (filter.maxDepth !== undefined) matchConditions['depth'] = { $lte: filter.maxDepth };
 		if (filter.minIntensity !== undefined) matchConditions['mw'] = { $gte: filter.minIntensity };
 		if (filter.maxIntensity !== undefined) matchConditions['mw'] = { $lte: filter.maxIntensity };
-		if (filter.minTime !== undefined) matchConditions['time'] = { $gte: new Date(filter.minTime).toISOString() };
-		if (filter.maxTime !== undefined) matchConditions['time'] = { $lte: new Date(filter.maxTime).toISOString() };
+		if (filter.minTime !== undefined)
+			matchConditions['time'] = { $gte: new Date(filter.minTime).toISOString() };
+		if (filter.maxTime !== undefined)
+			matchConditions['time'] = { $lte: new Date(filter.maxTime).toISOString() };
 		if (filter.geographicBound !== undefined) {
 			matchConditions['coord'] = {
 				$geoWithin: {

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -85,10 +85,10 @@ export async function getAllEarthquakeData(
 	if (filter) {
 		if (filter.minDepth !== undefined) matchConditions['depth'] = { $gte: filter.minDepth };
 		if (filter.maxDepth !== undefined) matchConditions['depth'] = { $lte: filter.maxDepth };
-		if (filter.minIntensity !== undefined) matchConditions['mi'] = { $gte: filter.minIntensity };
-		if (filter.maxIntensity !== undefined) matchConditions['mi'] = { $lte: filter.maxIntensity };
-		if (filter.minTime !== undefined) matchConditions['time'] = { $gte: new Date(filter.minTime) };
-		if (filter.maxTime !== undefined) matchConditions['time'] = { $lte: new Date(filter.maxTime) };
+		if (filter.minIntensity !== undefined) matchConditions['mw'] = { $gte: filter.minIntensity };
+		if (filter.maxIntensity !== undefined) matchConditions['mw'] = { $lte: filter.maxIntensity };
+		if (filter.minTime !== undefined) matchConditions['time'] = { $gte: new Date(filter.minTime).toISOString() };
+		if (filter.maxTime !== undefined) matchConditions['time'] = { $lte: new Date(filter.maxTime).toISOString() };
 		if (filter.geographicBound !== undefined) {
 			matchConditions['coord'] = {
 				$geoWithin: {

--- a/src/routes/reports/+page.server.ts
+++ b/src/routes/reports/+page.server.ts
@@ -1,9 +1,13 @@
+import { EarthquakeFilteringSchema, type EarthquakeFilters } from '$lib/model/src/event.js';
 import { Permission } from '$lib/model/src/user.js';
+import type { BoundingBox, Coordinates } from '$lib/model/src/util.js';
 import { getAllEarthquakeData, getUserFromSession } from '$lib/server/database/index.js';
 import { error } from '@sveltejs/kit';
 import { StatusCodes } from 'http-status-codes';
+import { z } from 'zod'
 
-export async function load({ cookies }) {
+const formKeys = ["maxDepth", "minDepth", "maxIntensity", "minIntensity", "radius", "limit", "tl_long", "tl_lat", "tr_long", "tr_lat", "bl_long", "bl_lat", "br_long", "br_lat", "c_long", "c_lat"]
+export async function load({ cookies, url: { searchParams }}) {
 	const sid = cookies.get('sid');
 	if (!sid) error(StatusCodes.UNAUTHORIZED);
 
@@ -11,6 +15,33 @@ export async function load({ cookies }) {
 	if (!user) error(StatusCodes.UNAUTHORIZED);
 	if (user.permission < Permission.RESEARCHER) error(StatusCodes.FORBIDDEN);
 
-	const { equakes } = await getAllEarthquakeData();
+	const query: Record<string, number | boolean | string | BoundingBox | Coordinates > = {};
+
+	searchParams.forEach((val, key) => {
+		if (formKeys.includes(key)) {
+			query[key] = z.coerce.number().parse(val)
+		}
+		else if (["minTime", "maxTime"].includes(key)) {
+			query[key] = z.coerce.string().datetime().parse(val);
+		}
+	})
+
+	const selected = z.coerce.number().parse(searchParams.get("selection"));
+
+	if (selected === 1) {
+		query['geographicBound'] = {
+			type: "Polygon",
+			coordinates: [[query.bl_long, query.bl_lat], [query.tl_long, query.tl_lat], [query.br_long, query.br_lat], [query.tr_long, query.tr_lat]]
+		} as BoundingBox;
+	} else if (selected === 2) {
+		query['coordinateCenter'] = {
+			type: "Point",
+			coordinates: [query.c_long, query.c_lat]
+		} as Coordinates;
+	}
+
+	const parsedQuery = EarthquakeFilteringSchema.parse(query)
+	console.log(parsedQuery)
+	const { equakes } = await getAllEarthquakeData(undefined, undefined, parsedQuery);
 	return { equakes };
 }

--- a/src/routes/reports/+page.server.ts
+++ b/src/routes/reports/+page.server.ts
@@ -4,10 +4,27 @@ import type { BoundingBox, Coordinates } from '$lib/model/src/util.js';
 import { getAllEarthquakeData, getUserFromSession } from '$lib/server/database/index.js';
 import { error } from '@sveltejs/kit';
 import { StatusCodes } from 'http-status-codes';
-import { z } from 'zod'
+import { z } from 'zod';
 
-const formKeys = ["maxDepth", "minDepth", "maxIntensity", "minIntensity", "radius", "limit", "tl_long", "tl_lat", "tr_long", "tr_lat", "bl_long", "bl_lat", "br_long", "br_lat", "c_long", "c_lat"]
-export async function load({ cookies, url: { searchParams }}) {
+const formKeys = [
+	'maxDepth',
+	'minDepth',
+	'maxIntensity',
+	'minIntensity',
+	'radius',
+	'limit',
+	'tl_long',
+	'tl_lat',
+	'tr_long',
+	'tr_lat',
+	'bl_long',
+	'bl_lat',
+	'br_long',
+	'br_lat',
+	'c_long',
+	'c_lat'
+];
+export async function load({ cookies, url: { searchParams } }) {
 	const sid = cookies.get('sid');
 	if (!sid) error(StatusCodes.UNAUTHORIZED);
 
@@ -15,33 +32,37 @@ export async function load({ cookies, url: { searchParams }}) {
 	if (!user) error(StatusCodes.UNAUTHORIZED);
 	if (user.permission < Permission.RESEARCHER) error(StatusCodes.FORBIDDEN);
 
-	const query: Record<string, number | boolean | string | BoundingBox | Coordinates > = {};
+	const query: Record<string, number | boolean | string | BoundingBox | Coordinates> = {};
 
 	searchParams.forEach((val, key) => {
 		if (formKeys.includes(key)) {
-			query[key] = z.coerce.number().parse(val)
-		}
-		else if (["minTime", "maxTime"].includes(key)) {
+			query[key] = z.coerce.number().parse(val);
+		} else if (['minTime', 'maxTime'].includes(key)) {
 			query[key] = z.coerce.string().datetime().parse(val);
 		}
-	})
+	});
 
-	const selected = z.coerce.number().parse(searchParams.get("selection"));
+	const selected = z.coerce.number().parse(searchParams.get('selection'));
 
 	if (selected === 1) {
 		query['geographicBound'] = {
-			type: "Polygon",
-			coordinates: [[query.bl_long, query.bl_lat], [query.tl_long, query.tl_lat], [query.br_long, query.br_lat], [query.tr_long, query.tr_lat]]
+			type: 'Polygon',
+			coordinates: [
+				[query.bl_long, query.bl_lat],
+				[query.tl_long, query.tl_lat],
+				[query.br_long, query.br_lat],
+				[query.tr_long, query.tr_lat]
+			]
 		} as BoundingBox;
 	} else if (selected === 2) {
 		query['coordinateCenter'] = {
-			type: "Point",
+			type: 'Point',
 			coordinates: [query.c_long, query.c_lat]
 		} as Coordinates;
 	}
 
-	const parsedQuery = EarthquakeFilteringSchema.parse(query)
-	console.log(parsedQuery)
+	const parsedQuery = EarthquakeFilteringSchema.parse(query);
+	console.log(parsedQuery);
 	const { equakes } = await getAllEarthquakeData(undefined, undefined, parsedQuery);
 	return { equakes };
 }

--- a/src/routes/reports/+page.svelte
+++ b/src/routes/reports/+page.svelte
@@ -15,7 +15,7 @@
 
 	<div>
 		Anything missing? Tell us!
-		<a href="/earthquake/submit">
+		<a href="/reports/query">
 			<button type="button" class="btn btn-sm variant-filled"> Submit </button>
 		</a>
 	</div>

--- a/src/routes/reports/query/+page.server.ts
+++ b/src/routes/reports/query/+page.server.ts
@@ -1,0 +1,74 @@
+import { error, fail, redirect } from '@sveltejs/kit';
+import { StatusCodes } from 'http-status-codes';
+import type { Actions } from './$types';
+//import { addEarthquakeData, getUserFromSession } from '$lib/server/database';
+import { getUserFromSession } from '$lib/server/database';
+import { Permission } from '$lib/model/src/user';
+import { parseOrZero } from '$lib/model/src/util';
+import { EarthquakeFilteringSchema } from '$lib/model/src/event';
+
+export const actions = {
+	async default({ cookies, request }) {
+		const form = await request.formData();
+
+		const time = form.get('time')?.toString();
+		if (time === undefined) return fail(StatusCodes.BAD_REQUEST, { missing: true });
+
+		const long = form.get('long')?.toString();
+		if (long === undefined) return fail(StatusCodes.BAD_REQUEST, { time, missing: true });
+
+		const lat = form.get('lat')?.toString();
+		if (lat === undefined) return fail(StatusCodes.BAD_REQUEST, { time, long, missing: true });
+
+		const depth = form.get('depth');
+		if (depth === null || depth instanceof File)
+			return fail(StatusCodes.BAD_REQUEST, { time, long, lat, missing: true });
+		const mi = form.get('mi')?.toString();
+		const mb = form.get('mb')?.toString();
+		const ms = form.get('ms')?.toString();
+		const mw = form.get('mw')?.toString();
+		if (mi === undefined && mb === undefined && ms === undefined && mw === undefined)
+			return fail(StatusCodes.BAD_REQUEST, { time, long, lat, depth, missing: true });
+
+		const li = form.get('li')?.toString();
+		if (li === undefined)
+			return fail(StatusCodes.BAD_REQUEST, { time, long, lat, depth, mw, missing: true });
+
+		const sid = cookies.get('sid');
+		if (!sid) return fail(StatusCodes.UNAUTHORIZED, { time, long, lat, depth, mw, authFail: true });
+		// A check can be done to see if a session exists.
+
+		const user = await getUserFromSession(sid);
+		if (user === false)
+			return fail(StatusCodes.UNAUTHORIZED, { time, long, lat, depth, mw, authFail: true });
+		if (user.permission < Permission.RESEARCHER)
+			return fail(StatusCodes.UNAUTHORIZED, { time, long, lat, depth, mw, noPerms: true });
+
+		const insert = {
+			time: new Date(time).toISOString(),
+			coord: {
+				type: 'Point',
+				coordinates: [parseFloat(long), parseFloat(lat)]
+			},
+			depth: parseInt(depth),
+			mi: parseOrZero(mi),
+			mb: parseOrZero(mb),
+			ms: parseOrZero(ms),
+			mw: parseOrZero(mw),
+			li: li ?? '',
+			title: ''
+		};
+
+		try {
+			const insertValidated = EarthquakeEventSchema.parse(insert);
+			const result = await addEarthquakeData(insertValidated);
+			const resId = result.toString();
+			if (typeof result === 'object') {
+				return redirect(StatusCodes.MOVED_TEMPORARILY, `/earthquake/${resId}`);
+			}
+			return fail(StatusCodes.BAD_REQUEST, { time, long, lat, depth, mw, li, parseFail: true });
+		} catch (err) {
+			throw err;
+		}
+	}
+} satisfies Actions;

--- a/src/routes/reports/query/+page.server.ts
+++ b/src/routes/reports/query/+page.server.ts
@@ -4,108 +4,33 @@ import type { Actions } from './$types';
 //import { addEarthquakeData, getUserFromSession } from '$lib/server/database';
 import { getUserFromSession } from '$lib/server/database';
 import { Permission } from '$lib/model/src/user';
-import { parseOrZero } from '$lib/model/src/util';
-import { EarthquakeFilteringSchema } from '$lib/model/src/event';
+import { parseIntOrZero, parseOrZero, type BoundingBox, type Coordinates } from '$lib/model/src/util';
+import { z } from 'zod'
 
+function filterParamHandler(form: FormData){
+	let param: Record<string, string> = {};
+
+	form.forEach((val, key) => {
+		console.log(val, key)
+		if (["maxDepth", "minDepth", "maxIntensity", "minIntensity", "radius", "limit"].includes(key)) {
+			console.log('in ' + key);
+			if (parseIntOrZero(val?.toString()) !== 0) {
+				const parse = z.coerce.number().safeParse(val?.toString());
+				if (parse.success) param[key] = parse.data.toString();
+			}	
+		}
+		else if (["minTime", "maxTime"].includes(key)) {
+			const parse = z.coerce.date().safeParse(val?.toString());
+			if (parse.success) param[key] = parse.data.toISOString();
+		}
+	});
+	console.log(param);
+	return new URLSearchParams(Object.entries(param));
+}
 export const actions = {
 	async default({ cookies, request }) {
 		const form = await request.formData();
-
-		/*
-		// I wasn't sure if this was the way
-		// to get the maxDepth and minDepth
-		const depth = form.get('depth');
-		if (depth === null || depth instanceof File)
-			return fail(StatusCodes.BAD_REQUEST, { time, long, lat, missing: true });
-		*/
-
-		const maxDepth = form.get('maxDepth')?.toString();
-		if (maxDepth === undefined) return fail(StatusCodes.BAD_REQUEST, { missing: true });
-
-		const minDepth = form.get('minDepth')?.toString();
-		if (minDepth === undefined) return fail(StatusCodes.BAD_REQUEST, { maxDepth, missing: true });
-
-		const maxIntensity = form.get('maxIntensity')?.toString();
-		if (maxIntensity === undefined) return fail(StatusCodes.BAD_REQUEST, { maxDepth, minDepth, missing: true });
-
-		const minIntensity = form.get('minIntensity')?.toString();
-		if (minIntensity === undefined) return fail(StatusCodes.BAD_REQUEST, { maxDepth, minDepth, maxIntensity, missing: true });
-
-		const maxTime = form.get('maxTime')?.toString();
-		if (maxTime === undefined) return fail(StatusCodes.BAD_REQUEST, { maxDepth, minDepth, maxIntensity, minIntensity, missing: true });
-
-		const minTime = form.get('minTime')?.toString();
-		if (minTime === undefined) return fail(StatusCodes.BAD_REQUEST, { maxDepth, minDepth, maxIntensity, minIntensity, maxTime, missing: true });
-
-		// TODO: add way to get geographicBound or coordinateCenter
-		// Notes:
-		// - to check for error, check if geographicBound is defined while coordinateCenter is NOT defined
-		//   or vice-versa (this results in no error)
-		// - Errors: both are defined, neither are defined
-
-
-		// DIVIDER (below is original)
-
-		/*
-		const time = form.get('time')?.toString();
-		if (time === undefined) return fail(StatusCodes.BAD_REQUEST, { missing: true });
-
-		const long = form.get('long')?.toString();
-		if (long === undefined) return fail(StatusCodes.BAD_REQUEST, { time, missing: true });
-
-		const lat = form.get('lat')?.toString();
-		if (lat === undefined) return fail(StatusCodes.BAD_REQUEST, { time, long, missing: true });
-
-		const depth = form.get('depth');
-		if (depth === null || depth instanceof File)
-			return fail(StatusCodes.BAD_REQUEST, { time, long, lat, missing: true });
-		const mi = form.get('mi')?.toString();
-		const mb = form.get('mb')?.toString();
-		const ms = form.get('ms')?.toString();
-		const mw = form.get('mw')?.toString();
-		if (mi === undefined && mb === undefined && ms === undefined && mw === undefined)
-			return fail(StatusCodes.BAD_REQUEST, { time, long, lat, depth, missing: true });
-
-		const li = form.get('li')?.toString();
-		if (li === undefined)
-			return fail(StatusCodes.BAD_REQUEST, { time, long, lat, depth, mw, missing: true });
-		*/
-
-		const sid = cookies.get('sid');
-		if (!sid) return fail(StatusCodes.UNAUTHORIZED, { maxDepth, minDepth, maxIntensity, minIntensity, maxTime, authFail: true });
-		// A check can be done to see if a session exists.
-
-		const user = await getUserFromSession(sid);
-		if (user === false)
-			return fail(StatusCodes.UNAUTHORIZED, { maxDepth, minDepth, maxIntensity, minIntensity, maxTime, authFail: true });
-		if (user.permission < Permission.RESEARCHER)
-			return fail(StatusCodes.UNAUTHORIZED, { maxDepth, minDepth, maxIntensity, minIntensity, maxTime, noPerms: true });
-
-		const insert = {
-			time: new Date(time).toISOString(),
-			coord: {
-				type: 'Point',
-				coordinates: [parseFloat(long), parseFloat(lat)]
-			},
-			depth: parseInt(depth),
-			mi: parseOrZero(mi),
-			mb: parseOrZero(mb),
-			ms: parseOrZero(ms),
-			mw: parseOrZero(mw),
-			li: li ?? '',
-			title: ''
-		};
-
-		try {
-			const insertValidated = EarthquakeEventSchema.parse(insert);
-			const result = await addEarthquakeData(insertValidated);
-			const resId = result.toString();
-			if (typeof result === 'object') {
-				return redirect(StatusCodes.MOVED_TEMPORARILY, `/earthquake/${resId}`);
-			}
-			return fail(StatusCodes.BAD_REQUEST, { time, long, lat, depth, mw, li, parseFail: true });
-		} catch (err) {
-			throw err;
-		}
+		const fitlerParams = filterParamHandler(form);
+		redirect(StatusCodes.MOVED_TEMPORARILY, `/reports?`+ fitlerParams)
 	}
 } satisfies Actions;

--- a/src/routes/reports/query/+page.server.ts
+++ b/src/routes/reports/query/+page.server.ts
@@ -11,6 +11,42 @@ export const actions = {
 	async default({ cookies, request }) {
 		const form = await request.formData();
 
+		/*
+		// I wasn't sure if this was the way
+		// to get the maxDepth and minDepth
+		const depth = form.get('depth');
+		if (depth === null || depth instanceof File)
+			return fail(StatusCodes.BAD_REQUEST, { time, long, lat, missing: true });
+		*/
+
+		const maxDepth = form.get('maxDepth')?.toString();
+		if (maxDepth === undefined) return fail(StatusCodes.BAD_REQUEST, { missing: true });
+
+		const minDepth = form.get('minDepth')?.toString();
+		if (minDepth === undefined) return fail(StatusCodes.BAD_REQUEST, { maxDepth, missing: true });
+
+		const maxIntensity = form.get('maxIntensity')?.toString();
+		if (maxIntensity === undefined) return fail(StatusCodes.BAD_REQUEST, { maxDepth, minDepth, missing: true });
+
+		const minIntensity = form.get('minIntensity')?.toString();
+		if (minIntensity === undefined) return fail(StatusCodes.BAD_REQUEST, { maxDepth, minDepth, maxIntensity, missing: true });
+
+		const maxTime = form.get('maxTime')?.toString();
+		if (maxTime === undefined) return fail(StatusCodes.BAD_REQUEST, { maxDepth, minDepth, maxIntensity, minIntensity, missing: true });
+
+		const minTime = form.get('minTime')?.toString();
+		if (minTime === undefined) return fail(StatusCodes.BAD_REQUEST, { maxDepth, minDepth, maxIntensity, minIntensity, maxTime, missing: true });
+
+		// TODO: add way to get geographicBound or coordinateCenter
+		// Notes:
+		// - to check for error, check if geographicBound is defined while coordinateCenter is NOT defined
+		//   or vice-versa (this results in no error)
+		// - Errors: both are defined, neither are defined
+
+
+		// DIVIDER (below is original)
+
+		/*
 		const time = form.get('time')?.toString();
 		if (time === undefined) return fail(StatusCodes.BAD_REQUEST, { missing: true });
 
@@ -33,16 +69,17 @@ export const actions = {
 		const li = form.get('li')?.toString();
 		if (li === undefined)
 			return fail(StatusCodes.BAD_REQUEST, { time, long, lat, depth, mw, missing: true });
+		*/
 
 		const sid = cookies.get('sid');
-		if (!sid) return fail(StatusCodes.UNAUTHORIZED, { time, long, lat, depth, mw, authFail: true });
+		if (!sid) return fail(StatusCodes.UNAUTHORIZED, { maxDepth, minDepth, maxIntensity, minIntensity, maxTime, authFail: true });
 		// A check can be done to see if a session exists.
 
 		const user = await getUserFromSession(sid);
 		if (user === false)
-			return fail(StatusCodes.UNAUTHORIZED, { time, long, lat, depth, mw, authFail: true });
+			return fail(StatusCodes.UNAUTHORIZED, { maxDepth, minDepth, maxIntensity, minIntensity, maxTime, authFail: true });
 		if (user.permission < Permission.RESEARCHER)
-			return fail(StatusCodes.UNAUTHORIZED, { time, long, lat, depth, mw, noPerms: true });
+			return fail(StatusCodes.UNAUTHORIZED, { maxDepth, minDepth, maxIntensity, minIntensity, maxTime, noPerms: true });
 
 		const insert = {
 			time: new Date(time).toISOString(),

--- a/src/routes/reports/query/+page.server.ts
+++ b/src/routes/reports/query/+page.server.ts
@@ -4,33 +4,53 @@ import type { Actions } from './$types';
 //import { addEarthquakeData, getUserFromSession } from '$lib/server/database';
 import { getUserFromSession } from '$lib/server/database';
 import { Permission } from '$lib/model/src/user';
-import { parseIntOrZero, parseOrZero, type BoundingBox, type Coordinates } from '$lib/model/src/util';
+import { parseIntOrZero, parseOrZero } from '$lib/model/src/util';
 import { z } from 'zod'
 
-function filterParamHandler(form: FormData){
-	let param: Record<string, string> = {};
+export async function load({cookies}) {
+	const sid = cookies.get('sid');
+	if (!sid) error(StatusCodes.UNAUTHORIZED);
 
-	form.forEach((val, key) => {
-		console.log(val, key)
-		if (["maxDepth", "minDepth", "maxIntensity", "minIntensity", "radius", "limit"].includes(key)) {
-			console.log('in ' + key);
-			if (parseIntOrZero(val?.toString()) !== 0) {
-				const parse = z.coerce.number().safeParse(val?.toString());
-				if (parse.success) param[key] = parse.data.toString();
-			}	
-		}
-		else if (["minTime", "maxTime"].includes(key)) {
-			const parse = z.coerce.date().safeParse(val?.toString());
-			if (parse.success) param[key] = parse.data.toISOString();
-		}
-	});
-	console.log(param);
-	return new URLSearchParams(Object.entries(param));
+	const user = await getUserFromSession(sid);
+	if (!user) error(StatusCodes.UNAUTHORIZED);
+	if (user.permission < Permission.RESEARCHER) error(StatusCodes.FORBIDDEN);
 }
+
+const formKeys = ["selection", "maxDepth", "minDepth", "maxIntensity", "minIntensity", "radius", "limit", "tl_long", "tl_lat", "tr_long", "tr_lat", "bl_long", "bl_lat", "br_long", "br_lat", "c_long", "c_lat"]
 export const actions = {
-	async default({ cookies, request }) {
+	async default({ request }) {
 		const form = await request.formData();
-		const fitlerParams = filterParamHandler(form);
+
+		let param: Record<string, string> = {};
+		form.forEach((val, key) => {
+			if (formKeys.includes(key)) {
+				if (parseOrZero(val?.toString()) !== 0) {
+					const parse = z.coerce.number().safeParse(val?.toString());
+					if (parse.success) param[key] = parse.data.toString();
+				}	
+			}
+			else if (["minTime", "maxTime"].includes(key)) {
+				const parse = z.coerce.date().safeParse(val?.toString());
+				if (parse.success) param[key] = parse.data.toISOString();
+			}
+		});
+		
+		const selection = parseIntOrZero(form.get('selection')?.toString());
+		const keys = Object.keys(param);
+
+		if (selection === 1) {
+			for (let key of ["tl_long", "tl_lat", "tr_long", "tr_lat", "bl_long", "bl_lat", "br_long", "br_lat"]) {
+				if (!keys.includes(key)) {
+					return fail(StatusCodes.BAD_REQUEST, {...param, missingCoord: true});
+				}
+			}
+		} else if (selection === 2) {
+			for (let key of ["c_long", "c_lat", "radius"]) {
+				if (!keys.includes(key)) return fail(StatusCodes.BAD_REQUEST, {...param, missingCoord: true});
+			}
+		}
+		
+		const fitlerParams = new URLSearchParams(Object.entries(param));
 		redirect(StatusCodes.MOVED_TEMPORARILY, `/reports?`+ fitlerParams)
 	}
 } satisfies Actions;

--- a/src/routes/reports/query/+page.server.ts
+++ b/src/routes/reports/query/+page.server.ts
@@ -5,9 +5,9 @@ import type { Actions } from './$types';
 import { getUserFromSession } from '$lib/server/database';
 import { Permission } from '$lib/model/src/user';
 import { parseIntOrZero, parseOrZero } from '$lib/model/src/util';
-import { z } from 'zod'
+import { z } from 'zod';
 
-export async function load({cookies}) {
+export async function load({ cookies }) {
 	const sid = cookies.get('sid');
 	if (!sid) error(StatusCodes.UNAUTHORIZED);
 
@@ -16,7 +16,25 @@ export async function load({cookies}) {
 	if (user.permission < Permission.RESEARCHER) error(StatusCodes.FORBIDDEN);
 }
 
-const formKeys = ["selection", "maxDepth", "minDepth", "maxIntensity", "minIntensity", "radius", "limit", "tl_long", "tl_lat", "tr_long", "tr_lat", "bl_long", "bl_lat", "br_long", "br_lat", "c_long", "c_lat"]
+const formKeys = [
+	'selection',
+	'maxDepth',
+	'minDepth',
+	'maxIntensity',
+	'minIntensity',
+	'radius',
+	'limit',
+	'tl_long',
+	'tl_lat',
+	'tr_long',
+	'tr_lat',
+	'bl_long',
+	'bl_lat',
+	'br_long',
+	'br_lat',
+	'c_long',
+	'c_lat'
+];
 export const actions = {
 	async default({ request }) {
 		const form = await request.formData();
@@ -27,30 +45,39 @@ export const actions = {
 				if (parseOrZero(val?.toString()) !== 0) {
 					const parse = z.coerce.number().safeParse(val?.toString());
 					if (parse.success) param[key] = parse.data.toString();
-				}	
-			}
-			else if (["minTime", "maxTime"].includes(key)) {
+				}
+			} else if (['minTime', 'maxTime'].includes(key)) {
 				const parse = z.coerce.date().safeParse(val?.toString());
 				if (parse.success) param[key] = parse.data.toISOString();
 			}
 		});
-		
+
 		const selection = parseIntOrZero(form.get('selection')?.toString());
 		const keys = Object.keys(param);
 
 		if (selection === 1) {
-			for (let key of ["tl_long", "tl_lat", "tr_long", "tr_lat", "bl_long", "bl_lat", "br_long", "br_lat"]) {
+			for (let key of [
+				'tl_long',
+				'tl_lat',
+				'tr_long',
+				'tr_lat',
+				'bl_long',
+				'bl_lat',
+				'br_long',
+				'br_lat'
+			]) {
 				if (!keys.includes(key)) {
-					return fail(StatusCodes.BAD_REQUEST, {...param, missingCoord: true});
+					return fail(StatusCodes.BAD_REQUEST, { ...param, missingCoord: true });
 				}
 			}
 		} else if (selection === 2) {
-			for (let key of ["c_long", "c_lat", "radius"]) {
-				if (!keys.includes(key)) return fail(StatusCodes.BAD_REQUEST, {...param, missingCoord: true});
+			for (let key of ['c_long', 'c_lat', 'radius']) {
+				if (!keys.includes(key))
+					return fail(StatusCodes.BAD_REQUEST, { ...param, missingCoord: true });
 			}
 		}
-		
+
 		const fitlerParams = new URLSearchParams(Object.entries(param));
-		redirect(StatusCodes.MOVED_TEMPORARILY, `/reports?`+ fitlerParams)
+		redirect(StatusCodes.MOVED_TEMPORARILY, `/reports?` + fitlerParams);
 	}
 } satisfies Actions;

--- a/src/routes/reports/query/+page.svelte
+++ b/src/routes/reports/query/+page.svelte
@@ -7,14 +7,13 @@
 	export let form;
 	let entryForm: HTMLFormElement;
 
-	let isBoundingBox:boolean;
-	$: isBoundingBox = true;
+	let selection = form?.selection ?? 0;
 </script>
 
 <h1 class="h1">Report Entry Submission</h1>
 <hr />
-{#if form?.authFail || form?.noPerms}
-	<LoginUserPromptError />
+{#if form?.missingCoord}
+	Missing Coordinate: {form}
 {/if}
 <form
 	method="POST"
@@ -38,17 +37,17 @@
 		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
 			<div class="input-group-shim">Maximum Magnitude</div>
 			<input type="number" min={0} name="maxIntensity" title="maxIntensity" step="any" value={form?.maxIntensity ?? ''} />
-			<!-- <div class="input-group-shim">km</div> -->
+			<div class="input-group-shim">Mw</div>
 		</div>
 
 		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
 			<div class="input-group-shim">Minimum Magnitude</div>
 			<input type="number" min={0} name="minIntensity" title="minIntensity" step="any" value={form?.minIntensity ?? ''} />
-			<!-- <div class="input-group-shim">km</div> -->
+			<div class="input-group-shim">Mw</div>
 		</div>
 
 		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
-			<div class="input-group-shim">Maximum Time</div>
+			<div class="input-group-shim">Search for Dates Before</div>
 			<input
 				name="maxTime"
 				title="Input Datetime for Earthquake Event"
@@ -58,7 +57,7 @@
 		</div>
 
 		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
-			<div class="input-group-shim">Minimum Time</div>
+			<div class="input-group-shim">Search for Dates After</div>
 			<input
 				name="minTime"
 				title="Input Datetime for Earthquake Event"
@@ -66,62 +65,71 @@
 				value={form?.minTime ?? ''}
 			/>
 		</div>
+		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
+			<div class="input-group-shim">Limit</div>
+			<input type="number" name="limit" title="limit" placeholder="Limit the affected locations here shown in the record to the X nearest locations." step="any" value={form?.limit ?? ''} />
+			<div class="input-group-shim">locations</div>
+		</div>
 
 		
 		<div class="space-y-2">
 			<label class="flex items-center space-x-2">
-				<input class="radio" bind:group={isBoundingBox} type="radio" checked name="radio-direct-1" value={true}/>
+				<input class="radio" bind:group={selection} type="radio" checked name="selection" value={0}/>
+				<p>No geographical search</p>
+			</label>
+			<label class="flex items-center space-x-2">
+				<input class="radio" bind:group={selection} type="radio" name="selection" value={1}/>
 				<p>Bounding Box - Give the 4 corner coordinates of affected areas</p>
 			</label>
 			<label class="flex items-center space-x-2">
-				<input class="radio" bind:group={isBoundingBox} type="radio" name="radio-direct-2" value={false} />
+				<input class="radio" bind:group={selection} type="radio" name="selection" value={2} />
 				<p>Radial Bounding - Give the center and radius to encapsulate the affected areas</p>
 			</label>
 		</div>
 
 					
 
-		{#if isBoundingBox}
+		{#if (selection === 1)}
 			<h2 class="h2">Bounding Box</h2>
 			<div class="input-group input-group-divider grid-cols-[0.6fr_1fr_1fr]">
 				<div class="input-group-shim">Top Left Coordinate</div>
-				<input type="number" name="TL_long" title="Longitude" placeholder="Longitude in °" step="any" 
-					value={form?.geographicBound.BoundingBoxSchema.coordinates[0][0] ?? ''} />
-				<input type="number" name="TL_lat" title="Latitude" placeholder="Latitude in °" step="any" 
-					value={form?.geographicBound.BoundingBoxSchema.coordinates[0][1] ?? ''} />
+				<input type="number" name="tl_long" title="Longitude" placeholder="Longitude in °" step="any" 
+					value={form?.tl_long ?? ''} />
+				<input type="number" name="tl_lat" title="Latitude" placeholder="Latitude in °" step="any" 
+					value={form?.tl_lat ?? ''} />
 			</div>
 
 			<div class="input-group input-group-divider grid-cols-[0.6fr_1fr_1fr]">
 				<div class="input-group-shim">Top Right Coordinate</div>
-				<input type="number" name="TR_long" title="Longitude" placeholder="Longitude in °" step="any" 
-					value={form?.geographicBound.BoundingBoxSchema.coordinates[1][0] ?? ''} />
-				<input type="number" name="TR_lat" title="Latitude" placeholder="Latitude in °" step="any" 
-					value={form?.geographicBound.BoundingBoxSchema.coordinates[1][1] ?? ''} />
+				<input type="number" name="tr_long" title="Longitude" placeholder="Longitude in °" step="any" 
+					value={form?.tr_long ?? ''} />
+				<input type="number" name="tr_lat" title="Latitude" placeholder="Latitude in °" step="any" 
+					value={form?.tr_lat ?? ''} />
 			</div>
 
 			<div class="input-group input-group-divider grid-cols-[0.6fr_1fr_1fr]">
 				<div class="input-group-shim">Bottom Left Coordinate</div>
-				<input type="number" name="BL_long" title="Longitude" placeholder="Longitude in °" step="any" 
-					value={form?.geographicBound.BoundingBoxSchema.coordinates[2][0] ?? ''} />
-				<input type="number" name="BL_lat" title="Latitude" placeholder="Latitude in °" step="any" 
-					value={form?.geographicBound.BoundingBoxSchema.coordinates[2][1] ?? ''} />
+				<input type="number" name="bl_long" title="Longitude" placeholder="Longitude in °" step="any" 
+					value={form?.bl_long ?? ''} />
+				<input type="number" name="bl_lat" title="Latitude" placeholder="Latitude in °" step="any" 
+					value={form?.bl_lat ?? ''} />
 			</div>
 
 			<div class="input-group input-group-divider grid-cols-[0.6fr_1fr_1fr]">
 				<div class="input-group-shim">Bottom Right Coordinate</div>
-				<input type="number" name="BR_long" title="Longitude" placeholder="Longitude in °" step="any" 
-					value={form?.geographicBound.BoundingBoxSchema.coordinates[3][0] ?? ''} />
-				<input type="number" name="BR_lat" title="Latitude" placeholder="Latitude in °" step="any" 
-					value={form?.geographicBound.BoundingBoxSchema.coordinates[3][1] ?? ''} />
+				<input type="number" name="br_long" title="Longitude" placeholder="Longitude in °" step="any" 
+					value={form?.br_long ?? ''} />
+				<input type="number" name="br_lat" title="Latitude" placeholder="Latitude in °" step="any" 
+					value={form?.br_lat ?? ''} />
 			</div>
-		{:else}
+		{:else if (selection === 2)}
 			<h2 class="h2">Radial Bounding</h2>
 			<div class="input-group input-group-divider grid-cols-[auto_1fr_1fr]">
 				<div class="input-group-shim">Center Coordinates</div>
-				<input type="number" name="BR_long" title="Longitude" placeholder="Longitude in °" step="any" 
-					value={form?.coordinateCenter.CoordinateSchema.coordinates[0] ?? ''} />
-				<input type="number" name="BR_lat" title="Latitude" placeholder="Latitude in °" step="any" 
-					value={form?.coordinateCenter.CoordinateSchema.coordinates[1] ?? ''} />
+				<input type="number" name="c_long" title="Longitude" placeholder="Longitude in °" step="any" 
+					value={form?.c_long ?? ''} />
+				<input type="number" name="c_lat" title="Latitude" placeholder="Latitude in °" step="any" 
+					value={form?.c_lat ?? ''} />
 			</div>
 
 			<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
@@ -129,16 +137,9 @@
 				<input type="number" name="radius" title="Radius" placeholder="Enter the radius of affected locations here." step="any" value={form?.radius ?? ''} />
 				<div class="input-group-shim">km</div>
 			</div>
-
-			<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
-				<div class="input-group-shim">Limit</div>
-				<input type="number" name="radius" title="Radius" placeholder="Limit the affected locations here shown in the record to the X nearest locations." step="any" value={form?.radius ?? ''} />
-				<div class="input-group-shim">locations</div>
-			</div>
-
 		{/if} 
 	</article>
 	<button type="button" class="btn btn-sm variant-filled" on:click={() => entryForm.requestSubmit()}
-		>Submit</button
+		>Search</button
 	>
 </form>

--- a/src/routes/reports/query/+page.svelte
+++ b/src/routes/reports/query/+page.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+	import LoginUserPromptError from '$lib/components/ui/LoginUserPromptError.svelte';
+
+	export let form;
+	let entryForm: HTMLFormElement;
+</script>
+
+<h1 class="h1">Earthquake Entry Submission</h1>
+<hr />
+{#if form?.authFail || form?.noPerms}
+	<LoginUserPromptError />
+{/if}
+<form
+	method="POST"
+	enctype="application/x-www-form-urlencoded"
+	class="flex-col flex card space-y-4 p4"
+	bind:this={entryForm}
+>
+	<article class="card flex-row m-4 p-1 space-y-3">
+		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
+			<div class="input-group-shim">Datetime</div>
+			<input
+				name="time"
+				title="Input Datetime for Earthquake Event"
+				type="datetime-local"
+				value={form?.time ?? ''}
+			/>
+		</div>
+		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
+			<div class="input-group-shim">Longitude</div>
+			<input
+				class:input-error={!form?.long && form?.missing}
+				type="number"
+				name="long"
+				title="Longitude"
+				step="any"
+				value={form?.long ?? ''}
+			/>
+			<div class="input-group-shim">°</div>
+		</div>
+		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
+			<div class="input-group-shim">Latitude</div>
+			<input type="number" name="lat" title="Latitude" step="any" value={form?.lat ?? ''} />
+			<div class="input-group-shim">°</div>
+		</div>
+		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
+			<div class="input-group-shim">Depth</div>
+			<input type="number" name="depth" title="Depth" step="any" value={form?.depth ?? ''} />
+			<div class="input-group-shim">km</div>
+		</div>
+		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
+			<div class="input-group-shim">Moment Magnitude</div>
+			<input type="number" name="mw" title="Magnitude" step="any" value={form?.mw ?? ''} />
+			<div class="input-group-shim">mw</div>
+		</div>
+		<textarea
+			name="li"
+			class="textarea"
+			rows="4"
+			placeholder="Enter local intensities."
+			value={form?.li ?? ''}
+		/>
+	</article>
+	<button type="button" class="btn btn-sm variant-filled" on:click={() => entryForm.requestSubmit()}
+		>Submit</button
+	>
+</form>

--- a/src/routes/reports/query/+page.svelte
+++ b/src/routes/reports/query/+page.svelte
@@ -1,8 +1,14 @@
 <script lang="ts">
-	import LoginUserPromptError from '$lib/components/ui/LoginUserPromptError.svelte';
+	import { RangeSlider } from '@skeletonlabs/skeleton';
+	import { RadioGroup, RadioItem } from '@skeletonlabs/skeleton';
 
+	import LoginUserPromptError from '$lib/components/ui/LoginUserPromptError.svelte';
+	
 	export let form;
 	let entryForm: HTMLFormElement;
+
+	let isBoundingBox:boolean;
+	$: isBoundingBox = true;
 </script>
 
 <h1 class="h1">Earthquake Entry Submission</h1>
@@ -18,48 +24,119 @@
 >
 	<article class="card flex-row m-4 p-1 space-y-3">
 		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
-			<div class="input-group-shim">Datetime</div>
-			<input
-				name="time"
-				title="Input Datetime for Earthquake Event"
-				type="datetime-local"
-				value={form?.time ?? ''}
-			/>
-		</div>
-		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
-			<div class="input-group-shim">Longitude</div>
-			<input
-				class:input-error={!form?.long && form?.missing}
-				type="number"
-				name="long"
-				title="Longitude"
-				step="any"
-				value={form?.long ?? ''}
-			/>
-			<div class="input-group-shim">°</div>
-		</div>
-		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
-			<div class="input-group-shim">Latitude</div>
-			<input type="number" name="lat" title="Latitude" step="any" value={form?.lat ?? ''} />
-			<div class="input-group-shim">°</div>
-		</div>
-		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
-			<div class="input-group-shim">Depth</div>
-			<input type="number" name="depth" title="Depth" step="any" value={form?.depth ?? ''} />
+			<div class="input-group-shim">Maximum Depth</div>
+			<input type="number" name="depth" title="maxDepth" step="any" value={form?.maxDepth ?? ''} />
 			<div class="input-group-shim">km</div>
 		</div>
+
 		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
-			<div class="input-group-shim">Moment Magnitude</div>
-			<input type="number" name="mw" title="Magnitude" step="any" value={form?.mw ?? ''} />
-			<div class="input-group-shim">mw</div>
+			<div class="input-group-shim">Minimum Depth</div>
+			<input type="number" name="depth" title="minDepth" step="any" value={form?.minDepth ?? ''} />
+			<div class="input-group-shim">km</div>
 		</div>
-		<textarea
-			name="li"
-			class="textarea"
-			rows="4"
-			placeholder="Enter local intensities."
-			value={form?.li ?? ''}
-		/>
+
+		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
+			<div class="input-group-shim">Maximum Magnitude</div>
+			<input type="number" min={0} name="maxIntensity" title="maxIntensity" step="any" value={form?.maxIntensity ?? ''} />
+			<!-- <div class="input-group-shim">km</div> -->
+		</div>
+
+		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
+			<div class="input-group-shim">Minimum Magnitude</div>
+			<input type="number" min={0} name="minIntensity" title="minIntensity" step="any" value={form?.minIntensity ?? ''} />
+			<!-- <div class="input-group-shim">km</div> -->
+		</div>
+
+		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
+			<div class="input-group-shim">Maximum Time</div>
+			<input
+				name="maxTime"
+				title="Input Datetime for Earthquake Event"
+				type="datetime-local"
+				value={form?.maxTime ?? ''}
+			/>
+		</div>
+
+		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
+			<div class="input-group-shim">Minimum Time</div>
+			<input
+				name="minTime"
+				title="Input Datetime for Earthquake Event"
+				type="datetime-local"
+				value={form?.minTime ?? ''}
+			/>
+		</div>
+
+		
+		<div class="space-y-2">
+			<label class="flex items-center space-x-2">
+				<input class="radio" bind:group={isBoundingBox} type="radio" checked name="radio-direct-1" value={true}/>
+				<p>Bounding Box - Give the 4 corner coordinates of affected areas</p>
+			</label>
+			<label class="flex items-center space-x-2">
+				<input class="radio" bind:group={isBoundingBox} type="radio" name="radio-direct-2" value={false} />
+				<p>Radial Bounding - Give the center and radius to encapsulate the affected areas</p>
+			</label>
+		</div>
+
+					
+
+		{#if isBoundingBox}
+			<h2 class="h2">Bounding Box</h2>
+			<div class="input-group input-group-divider grid-cols-[0.6fr_1fr_1fr]">
+				<div class="input-group-shim">Top Left Coordinate</div>
+				<input type="number" name="TL_long" title="Longitude" placeholder="Longitude in °" step="any" 
+					value={form?.geographicBound.BoundingBoxSchema.coordinates[0][0] ?? ''} />
+				<input type="number" name="TL_lat" title="Latitude" placeholder="Latitude in °" step="any" 
+					value={form?.geographicBound.BoundingBoxSchema.coordinates[0][1] ?? ''} />
+			</div>
+
+			<div class="input-group input-group-divider grid-cols-[0.6fr_1fr_1fr]">
+				<div class="input-group-shim">Top Right Coordinate</div>
+				<input type="number" name="TR_long" title="Longitude" placeholder="Longitude in °" step="any" 
+					value={form?.geographicBound.BoundingBoxSchema.coordinates[1][0] ?? ''} />
+				<input type="number" name="TR_lat" title="Latitude" placeholder="Latitude in °" step="any" 
+					value={form?.geographicBound.BoundingBoxSchema.coordinates[1][1] ?? ''} />
+			</div>
+
+			<div class="input-group input-group-divider grid-cols-[0.6fr_1fr_1fr]">
+				<div class="input-group-shim">Bottom Left Coordinate</div>
+				<input type="number" name="BL_long" title="Longitude" placeholder="Longitude in °" step="any" 
+					value={form?.geographicBound.BoundingBoxSchema.coordinates[2][0] ?? ''} />
+				<input type="number" name="BL_lat" title="Latitude" placeholder="Latitude in °" step="any" 
+					value={form?.geographicBound.BoundingBoxSchema.coordinates[2][1] ?? ''} />
+			</div>
+
+			<div class="input-group input-group-divider grid-cols-[0.6fr_1fr_1fr]">
+				<div class="input-group-shim">Bottom Right Coordinate</div>
+				<input type="number" name="BR_long" title="Longitude" placeholder="Longitude in °" step="any" 
+					value={form?.geographicBound.BoundingBoxSchema.coordinates[3][0] ?? ''} />
+				<input type="number" name="BR_lat" title="Latitude" placeholder="Latitude in °" step="any" 
+					value={form?.geographicBound.BoundingBoxSchema.coordinates[3][1] ?? ''} />
+			</div>
+		{:else}
+			<h2 class="h2">Radial Bounding</h2>
+			<div class="input-group input-group-divider grid-cols-[auto_1fr_1fr]">
+				<div class="input-group-shim">Center Coordinates</div>
+				<input type="number" name="BR_long" title="Longitude" placeholder="Longitude in °" step="any" 
+					value={form?.coordinateCenter.CoordinateSchema.coordinates[0] ?? ''} />
+				<input type="number" name="BR_lat" title="Latitude" placeholder="Latitude in °" step="any" 
+					value={form?.coordinateCenter.CoordinateSchema.coordinates[1] ?? ''} />
+			</div>
+
+			<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
+				<div class="input-group-shim">Radius</div>
+				<input type="number" name="radius" title="Radius" placeholder="Enter the radius of affected locations here." step="any" value={form?.radius ?? ''} />
+				<div class="input-group-shim">km</div>
+			</div>
+
+			<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
+				<div class="input-group-shim">Limit</div>
+				<input type="number" name="radius" title="Radius" placeholder="Limit the affected locations here shown in the record to the X nearest locations." step="any" value={form?.radius ?? ''} />
+				<div class="input-group-shim">locations</div>
+			</div>
+
+		{/if} 
 	</article>
 	<button type="button" class="btn btn-sm variant-filled" on:click={() => entryForm.requestSubmit()}
 		>Submit</button

--- a/src/routes/reports/query/+page.svelte
+++ b/src/routes/reports/query/+page.svelte
@@ -11,7 +11,7 @@
 	$: isBoundingBox = true;
 </script>
 
-<h1 class="h1">Earthquake Entry Submission</h1>
+<h1 class="h1">Report Entry Submission</h1>
 <hr />
 {#if form?.authFail || form?.noPerms}
 	<LoginUserPromptError />

--- a/src/routes/reports/query/+page.svelte
+++ b/src/routes/reports/query/+page.svelte
@@ -25,13 +25,13 @@
 	<article class="card flex-row m-4 p-1 space-y-3">
 		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
 			<div class="input-group-shim">Maximum Depth</div>
-			<input type="number" name="depth" title="maxDepth" step="any" value={form?.maxDepth ?? ''} />
+			<input type="number" name="maxDepth" title="maxDepth" step="any" value={form?.maxDepth ?? ''} />
 			<div class="input-group-shim">km</div>
 		</div>
 
 		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
 			<div class="input-group-shim">Minimum Depth</div>
-			<input type="number" name="depth" title="minDepth" step="any" value={form?.minDepth ?? ''} />
+			<input type="number" name="minDepth" title="minDepth" step="any" value={form?.minDepth ?? ''} />
 			<div class="input-group-shim">km</div>
 		</div>
 

--- a/src/routes/reports/query/+page.svelte
+++ b/src/routes/reports/query/+page.svelte
@@ -3,7 +3,7 @@
 	import { RadioGroup, RadioItem } from '@skeletonlabs/skeleton';
 
 	import LoginUserPromptError from '$lib/components/ui/LoginUserPromptError.svelte';
-	
+
 	export let form;
 	let entryForm: HTMLFormElement;
 
@@ -24,25 +24,51 @@
 	<article class="card flex-row m-4 p-1 space-y-3">
 		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
 			<div class="input-group-shim">Maximum Depth</div>
-			<input type="number" name="maxDepth" title="maxDepth" step="any" value={form?.maxDepth ?? ''} />
+			<input
+				type="number"
+				name="maxDepth"
+				title="maxDepth"
+				step="any"
+				value={form?.maxDepth ?? ''}
+			/>
 			<div class="input-group-shim">km</div>
 		</div>
 
 		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
 			<div class="input-group-shim">Minimum Depth</div>
-			<input type="number" name="minDepth" title="minDepth" step="any" value={form?.minDepth ?? ''} />
+			<input
+				type="number"
+				name="minDepth"
+				title="minDepth"
+				step="any"
+				value={form?.minDepth ?? ''}
+			/>
 			<div class="input-group-shim">km</div>
 		</div>
 
 		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
 			<div class="input-group-shim">Maximum Magnitude</div>
-			<input type="number" min={0} name="maxIntensity" title="maxIntensity" step="any" value={form?.maxIntensity ?? ''} />
+			<input
+				type="number"
+				min={0}
+				name="maxIntensity"
+				title="maxIntensity"
+				step="any"
+				value={form?.maxIntensity ?? ''}
+			/>
 			<div class="input-group-shim">Mw</div>
 		</div>
 
 		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
 			<div class="input-group-shim">Minimum Magnitude</div>
-			<input type="number" min={0} name="minIntensity" title="minIntensity" step="any" value={form?.minIntensity ?? ''} />
+			<input
+				type="number"
+				min={0}
+				name="minIntensity"
+				title="minIntensity"
+				step="any"
+				value={form?.minIntensity ?? ''}
+			/>
 			<div class="input-group-shim">Mw</div>
 		</div>
 
@@ -67,18 +93,31 @@
 		</div>
 		<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
 			<div class="input-group-shim">Limit</div>
-			<input type="number" name="limit" title="limit" placeholder="Limit the affected locations here shown in the record to the X nearest locations." step="any" value={form?.limit ?? ''} />
+			<input
+				type="number"
+				name="limit"
+				title="limit"
+				placeholder="Limit the affected locations here shown in the record to the X nearest locations."
+				step="any"
+				value={form?.limit ?? ''}
+			/>
 			<div class="input-group-shim">locations</div>
 		</div>
 
-		
 		<div class="space-y-2">
 			<label class="flex items-center space-x-2">
-				<input class="radio" bind:group={selection} type="radio" checked name="selection" value={0}/>
+				<input
+					class="radio"
+					bind:group={selection}
+					type="radio"
+					checked
+					name="selection"
+					value={0}
+				/>
 				<p>No geographical search</p>
 			</label>
 			<label class="flex items-center space-x-2">
-				<input class="radio" bind:group={selection} type="radio" name="selection" value={1}/>
+				<input class="radio" bind:group={selection} type="radio" name="selection" value={1} />
 				<p>Bounding Box - Give the 4 corner coordinates of affected areas</p>
 			</label>
 			<label class="flex items-center space-x-2">
@@ -87,57 +126,122 @@
 			</label>
 		</div>
 
-					
-
-		{#if (selection === 1)}
+		{#if selection === 1}
 			<h2 class="h2">Bounding Box</h2>
 			<div class="input-group input-group-divider grid-cols-[0.6fr_1fr_1fr]">
 				<div class="input-group-shim">Top Left Coordinate</div>
-				<input type="number" name="tl_long" title="Longitude" placeholder="Longitude in °" step="any" 
-					value={form?.tl_long ?? ''} />
-				<input type="number" name="tl_lat" title="Latitude" placeholder="Latitude in °" step="any" 
-					value={form?.tl_lat ?? ''} />
+				<input
+					type="number"
+					name="tl_long"
+					title="Longitude"
+					placeholder="Longitude in °"
+					step="any"
+					value={form?.tl_long ?? ''}
+				/>
+				<input
+					type="number"
+					name="tl_lat"
+					title="Latitude"
+					placeholder="Latitude in °"
+					step="any"
+					value={form?.tl_lat ?? ''}
+				/>
 			</div>
 
 			<div class="input-group input-group-divider grid-cols-[0.6fr_1fr_1fr]">
 				<div class="input-group-shim">Top Right Coordinate</div>
-				<input type="number" name="tr_long" title="Longitude" placeholder="Longitude in °" step="any" 
-					value={form?.tr_long ?? ''} />
-				<input type="number" name="tr_lat" title="Latitude" placeholder="Latitude in °" step="any" 
-					value={form?.tr_lat ?? ''} />
+				<input
+					type="number"
+					name="tr_long"
+					title="Longitude"
+					placeholder="Longitude in °"
+					step="any"
+					value={form?.tr_long ?? ''}
+				/>
+				<input
+					type="number"
+					name="tr_lat"
+					title="Latitude"
+					placeholder="Latitude in °"
+					step="any"
+					value={form?.tr_lat ?? ''}
+				/>
 			</div>
 
 			<div class="input-group input-group-divider grid-cols-[0.6fr_1fr_1fr]">
 				<div class="input-group-shim">Bottom Left Coordinate</div>
-				<input type="number" name="bl_long" title="Longitude" placeholder="Longitude in °" step="any" 
-					value={form?.bl_long ?? ''} />
-				<input type="number" name="bl_lat" title="Latitude" placeholder="Latitude in °" step="any" 
-					value={form?.bl_lat ?? ''} />
+				<input
+					type="number"
+					name="bl_long"
+					title="Longitude"
+					placeholder="Longitude in °"
+					step="any"
+					value={form?.bl_long ?? ''}
+				/>
+				<input
+					type="number"
+					name="bl_lat"
+					title="Latitude"
+					placeholder="Latitude in °"
+					step="any"
+					value={form?.bl_lat ?? ''}
+				/>
 			</div>
 
 			<div class="input-group input-group-divider grid-cols-[0.6fr_1fr_1fr]">
 				<div class="input-group-shim">Bottom Right Coordinate</div>
-				<input type="number" name="br_long" title="Longitude" placeholder="Longitude in °" step="any" 
-					value={form?.br_long ?? ''} />
-				<input type="number" name="br_lat" title="Latitude" placeholder="Latitude in °" step="any" 
-					value={form?.br_lat ?? ''} />
+				<input
+					type="number"
+					name="br_long"
+					title="Longitude"
+					placeholder="Longitude in °"
+					step="any"
+					value={form?.br_long ?? ''}
+				/>
+				<input
+					type="number"
+					name="br_lat"
+					title="Latitude"
+					placeholder="Latitude in °"
+					step="any"
+					value={form?.br_lat ?? ''}
+				/>
 			</div>
-		{:else if (selection === 2)}
+		{:else if selection === 2}
 			<h2 class="h2">Radial Bounding</h2>
 			<div class="input-group input-group-divider grid-cols-[auto_1fr_1fr]">
 				<div class="input-group-shim">Center Coordinates</div>
-				<input type="number" name="c_long" title="Longitude" placeholder="Longitude in °" step="any" 
-					value={form?.c_long ?? ''} />
-				<input type="number" name="c_lat" title="Latitude" placeholder="Latitude in °" step="any" 
-					value={form?.c_lat ?? ''} />
+				<input
+					type="number"
+					name="c_long"
+					title="Longitude"
+					placeholder="Longitude in °"
+					step="any"
+					value={form?.c_long ?? ''}
+				/>
+				<input
+					type="number"
+					name="c_lat"
+					title="Latitude"
+					placeholder="Latitude in °"
+					step="any"
+					value={form?.c_lat ?? ''}
+				/>
 			</div>
 
 			<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
 				<div class="input-group-shim">Radius</div>
-				<input type="number" name="radius" title="Radius" placeholder="Enter the radius of affected locations here." step="any" value={form?.radius ?? ''} />
+				<input
+					type="number"
+					name="radius"
+					title="Radius"
+					placeholder="Enter the radius of affected locations here."
+					step="any"
+					value={form?.radius ?? ''}
+				/>
 				<div class="input-group-shim">km</div>
 			</div>
-		{/if} 
+		{/if}
 	</article>
 	<button type="button" class="btn btn-sm variant-filled" on:click={() => entryForm.requestSubmit()}
 		>Search</button


### PR DESCRIPTION
This pull request is dedicated to adding the frontend functionality of the `/reports/query` route. 
The following features added were:
- submission page for each field in the schema (including the more advanced information which are `geographicBound`, `coordinateCenter`, `radius`, and `limit`)
   - note that the `orderDepth`, `orderIntensity`, and `orderTime` schemas were not used as the form is already explicit with what it needs and which field is which
   - this is because there are respective `max` and `min` fields for `Depth`, `Intensity`, and `Time`
- partial HTML form submission
   - the basic information (`Depth`, `Intensity`, `Time`) are all taken into the `+page.server.ts` 
   - the more advanced information are still yet to be processed